### PR TITLE
[feat] 기본 사용자 ui 코드 추가

### DIFF
--- a/frontend/user/app.py
+++ b/frontend/user/app.py
@@ -1,0 +1,102 @@
+import streamlit as st
+import time
+import uuid
+
+# CSS 파일 적용
+with open("style.css", encoding='utf-8') as f:
+    css = f.read()
+    st.markdown(f"<style>{css}</style>", unsafe_allow_html=True)
+
+def generate_response(user_input):
+    return f"{user_input}"  # 그대로 출력
+
+#유사도 비교 정보를 보여줄 화면
+@st.dialog("유사도 비교 결과")
+def show_detail(message):
+    st.write(message)
+    if st.button('ok'):
+        st.rerun()
+
+# 세션 상태 초기화
+if 'chats' not in st.session_state:
+    st.session_state['chats'] = {} # 대화를 저장하는 딕셔너리
+    st.session_state['chat_count'] = 1 # 대화 번호
+    st.session_state['current_chat'] = "대화1" # 현재 대화 이름 저장
+
+# 대화1 생성
+if st.session_state['current_chat'] not in st.session_state['chats']:
+    st.session_state['chats'][st.session_state['current_chat']] = []
+
+# 사이드바
+with st.sidebar:
+    if st.button("새 대화 시작"):
+        st.session_state['chat_count'] += 1
+        new_chat_name = f"대화{st.session_state['chat_count']}"
+        st.session_state['current_chat'] = new_chat_name
+        st.session_state['chats'][new_chat_name] = []
+        st.rerun()
+
+    previous_chats = list(st.session_state['chats'].keys())
+    st.subheader("이전 대화")
+    for chat_name in previous_chats:
+        if st.button(chat_name, key=chat_name):
+            st.session_state['current_chat'] = chat_name
+            st.rerun()
+
+# 메인 화면
+st.title("Streamlit Chatbot")
+
+if not st.session_state['chats'][st.session_state['current_chat']]:
+    st.markdown("""
+        ### 환영합니다!
+        - 이 챗봇은 생성형 AI를 활용하여 질문에 답변합니다.
+        - 사이드바에서 파일을 업로드하거나, 이전 대화를 불러올 수 있습니다.
+        - 질문을 입력하면 AI가 답변해줍니다. 😊
+    """)
+
+# 채팅 메시지 출력
+messages = st.session_state['chats'][st.session_state['current_chat']]
+for i, (query, reply) in enumerate(messages):
+    unique_key = str(uuid.uuid4())  # 각 메시지마다 고유한 UUID 생성
+
+    # 사용자 질문
+    st.markdown(f"<div class='chat-container'><div class='user-message'>{query}</div></div>", unsafe_allow_html=True)
+
+    # AI 답변
+    st.markdown(f"<div class='chat-container'><div class='ai-message'>{reply}</div></div>", unsafe_allow_html=True)
+
+    if st.button(f"📄 유사도 비교 정보", key=f"dialog_{i}"):
+        show_detail("유사도 비교 정보~~~")
+
+# 마지막 메시지에만 답변 재생성 버튼 생성
+if len(messages) > 0:
+    last_query, last_reply = messages[-1]  # 마지막 질문과 답변
+
+    # 답변 재생성 버튼
+    if st.button("🔄 답변 재생성", key=f"regen_{st.session_state['current_chat']}_last"):
+        with st.spinner("답변 생성 중..."):
+            new_response = generate_response(last_query)
+            messages[-1] = (last_query, new_response)  # 마지막 메시지에 대해 새로운 답변을 설정
+            st.session_state['chats'][st.session_state['current_chat']] = messages
+            st.rerun()
+
+# 사용자 입력 받기
+user_input = st.chat_input("질문을 입력하거나 파일을 업로드하세요:", accept_file='multiple')
+
+# 파일이 업로드된 경우
+if user_input and user_input.files:
+    for uploaded_file in user_input.files:
+        file_content = uploaded_file.read().decode("utf-8")  # 파일을 문자열로 변환
+        response = generate_response(file_content)
+        messages.append((f"📂 {uploaded_file.name}", response))  # 파일명과 응답 저장
+    st.session_state['chats'][st.session_state['current_chat']] = messages
+    st.rerun()
+
+# 텍스트 입력이 있는 경우
+elif user_input and user_input.text:
+    with st.spinner("답변 생성 중..."):
+        time.sleep(1)
+        response = generate_response(user_input.text)
+        messages.append((user_input.text, response))
+        st.session_state['chats'][st.session_state['current_chat']] = messages
+        st.rerun()

--- a/frontend/user/app.py
+++ b/frontend/user/app.py
@@ -1,47 +1,22 @@
 import streamlit as st
 import time
-import uuid
+from response import generate_response
+from session_manager import init_session_state
+from sidebar import display_sidebar
+from chat_ui import display_chat_messages
+from file_handler import handle_file_upload
+from similarity import show_detail
 
 # CSS 파일 적용
 with open("style.css", encoding='utf-8') as f:
     css = f.read()
     st.markdown(f"<style>{css}</style>", unsafe_allow_html=True)
 
-def generate_response(user_input):
-    return f"{user_input}"  # 그대로 출력
-
-#유사도 비교 정보를 보여줄 화면
-@st.dialog("유사도 비교 결과")
-def show_detail(message):
-    st.write(message)
-    if st.button('ok'):
-        st.rerun()
-
 # 세션 상태 초기화
-if 'chats' not in st.session_state:
-    st.session_state['chats'] = {} # 대화를 저장하는 딕셔너리
-    st.session_state['chat_count'] = 1 # 대화 번호
-    st.session_state['current_chat'] = "대화1" # 현재 대화 이름 저장
+init_session_state()
 
-# 대화1 생성
-if st.session_state['current_chat'] not in st.session_state['chats']:
-    st.session_state['chats'][st.session_state['current_chat']] = []
-
-# 사이드바
-with st.sidebar:
-    if st.button("새 대화 시작"):
-        st.session_state['chat_count'] += 1
-        new_chat_name = f"대화{st.session_state['chat_count']}"
-        st.session_state['current_chat'] = new_chat_name
-        st.session_state['chats'][new_chat_name] = []
-        st.rerun()
-
-    previous_chats = list(st.session_state['chats'].keys())
-    st.subheader("이전 대화")
-    for chat_name in previous_chats:
-        if st.button(chat_name, key=chat_name):
-            st.session_state['current_chat'] = chat_name
-            st.rerun()
+# 사이드바 표시
+display_sidebar()
 
 # 메인 화면
 st.title("Streamlit Chatbot")
@@ -55,48 +30,19 @@ if not st.session_state['chats'][st.session_state['current_chat']]:
     """)
 
 # 채팅 메시지 출력
-messages = st.session_state['chats'][st.session_state['current_chat']]
-for i, (query, reply) in enumerate(messages):
-    unique_key = str(uuid.uuid4())  # 각 메시지마다 고유한 UUID 생성
-
-    # 사용자 질문
-    st.markdown(f"<div class='chat-container'><div class='user-message'>{query}</div></div>", unsafe_allow_html=True)
-
-    # AI 답변
-    st.markdown(f"<div class='chat-container'><div class='ai-message'>{reply}</div></div>", unsafe_allow_html=True)
-
-    if st.button(f"📄 유사도 비교 정보", key=f"dialog_{i}"):
-        show_detail("유사도 비교 정보~~~")
-
-# 마지막 메시지에만 답변 재생성 버튼 생성
-if len(messages) > 0:
-    last_query, last_reply = messages[-1]  # 마지막 질문과 답변
-
-    # 답변 재생성 버튼
-    if st.button("🔄 답변 재생성", key=f"regen_{st.session_state['current_chat']}_last"):
-        with st.spinner("답변 생성 중..."):
-            new_response = generate_response(last_query)
-            messages[-1] = (last_query, new_response)  # 마지막 메시지에 대해 새로운 답변을 설정
-            st.session_state['chats'][st.session_state['current_chat']] = messages
-            st.rerun()
+display_chat_messages()
 
 # 사용자 입력 받기
 user_input = st.chat_input("질문을 입력하거나 파일을 업로드하세요:", accept_file='multiple')
 
-# 파일이 업로드된 경우
+# 파일 업로드 처리
 if user_input and user_input.files:
-    for uploaded_file in user_input.files:
-        file_content = uploaded_file.read().decode("utf-8")  # 파일을 문자열로 변환
-        response = generate_response(file_content)
-        messages.append((f"📂 {uploaded_file.name}", response))  # 파일명과 응답 저장
-    st.session_state['chats'][st.session_state['current_chat']] = messages
-    st.rerun()
+    handle_file_upload(user_input.files)
 
-# 텍스트 입력이 있는 경우
+# 텍스트 입력 처리
 elif user_input and user_input.text:
     with st.spinner("답변 생성 중..."):
         time.sleep(1)
         response = generate_response(user_input.text)
-        messages.append((user_input.text, response))
-        st.session_state['chats'][st.session_state['current_chat']] = messages
+        st.session_state['chats'][st.session_state['current_chat']].append((user_input.text, response))
         st.rerun()

--- a/frontend/user/chat_ui.py
+++ b/frontend/user/chat_ui.py
@@ -1,0 +1,29 @@
+import streamlit as st
+import uuid
+from response import generate_response
+from similarity import show_detail
+
+def display_chat_messages():
+    messages = st.session_state['chats'][st.session_state['current_chat']]
+    for i, (query, reply) in enumerate(messages):
+        unique_key = str(uuid.uuid4())  # 각 메시지마다 고유한 UUID 생성
+
+        # 사용자 질문
+        st.markdown(f"<div class='chat-container'><div class='user-message'>{query}</div></div>", unsafe_allow_html=True)
+
+        # AI 답변
+        st.markdown(f"<div class='chat-container'><div class='ai-message'>{reply}</div></div>", unsafe_allow_html=True)
+
+        if st.button(f"📄 유사도 비교 정보", key=f"dialog_{i}"):
+            show_detail("유사도 비교 정보~~~")
+
+    # 마지막 메시지에만 답변 재생성 버튼 생성
+    if len(messages) > 0:
+        last_query, last_reply = messages[-1]
+
+        if st.button("🔄 답변 재생성", key=f"regen_{st.session_state['current_chat']}_last"):
+            with st.spinner("답변 생성 중..."):
+                new_response = generate_response(last_query)
+                messages[-1] = (last_query, new_response)
+                st.session_state['chats'][st.session_state['current_chat']] = messages
+                st.rerun()

--- a/frontend/user/file_handler.py
+++ b/frontend/user/file_handler.py
@@ -1,0 +1,13 @@
+import streamlit as st
+from response import generate_response
+
+def handle_file_upload(files):
+    messages = st.session_state['chats'][st.session_state['current_chat']]
+    
+    for uploaded_file in files:
+        file_content = uploaded_file.read().decode("utf-8")  # 파일을 문자열로 변환
+        response = generate_response(file_content)
+        messages.append((f"📂 {uploaded_file.name}", response))  # 파일명과 응답 저장
+
+    st.session_state['chats'][st.session_state['current_chat']] = messages
+    st.rerun()

--- a/frontend/user/response.py
+++ b/frontend/user/response.py
@@ -1,0 +1,2 @@
+def generate_response(user_input):
+    return f"{user_input}"  # 그대로 출력

--- a/frontend/user/session_manager.py
+++ b/frontend/user/session_manager.py
@@ -1,0 +1,11 @@
+import streamlit as st
+
+def init_session_state():
+    if 'chats' not in st.session_state:
+        st.session_state['chats'] = {}  # 대화를 저장하는 딕셔너리
+        st.session_state['chat_count'] = 1  # 대화 번호
+        st.session_state['current_chat'] = "대화1"  # 현재 대화 이름 저장
+
+    # 대화1 생성
+    if st.session_state['current_chat'] not in st.session_state['chats']:
+        st.session_state['chats'][st.session_state['current_chat']] = []

--- a/frontend/user/sidebar.py
+++ b/frontend/user/sidebar.py
@@ -1,0 +1,15 @@
+import streamlit as st
+
+def display_sidebar():
+    with st.sidebar:
+        if st.button("새 대화 시작"):
+            st.session_state['chat_count'] += 1
+            new_chat_name = f"대화{st.session_state['chat_count']}"
+            st.session_state['current_chat'] = new_chat_name
+            st.session_state['chats'][new_chat_name] = []
+
+        previous_chats = list(st.session_state['chats'].keys())
+        st.subheader("이전 대화")
+        for chat_name in previous_chats:
+            if st.button(chat_name, key=chat_name):
+                st.session_state['current_chat'] = chat_name

--- a/frontend/user/similarity.py
+++ b/frontend/user/similarity.py
@@ -1,0 +1,7 @@
+import streamlit as st
+
+@st.dialog("유사도 비교")
+def show_detail(message):
+    st.write(message)
+    if st.button('ok'):
+        st.rerun()

--- a/frontend/user/style.css
+++ b/frontend/user/style.css
@@ -1,6 +1,17 @@
+@font-face {
+    font-family: 'Pretendard-Regular';
+    src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff') format('woff');
+    font-weight: 400;
+    font-style: normal;
+}
+
+:root {
+    --maincolor: yellow;
+}
+
 /* 기본 스타일 */
 body {
-    font-family: 'Arial', sans-serif;
+    font-family: 'Pretendard-Regular', sans-serif;
     background-color: #f7f7f7;
     padding: 20px;
 }
@@ -34,4 +45,5 @@ body {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
+    background-color: var(--maincolor);
 }

--- a/frontend/user/style.css
+++ b/frontend/user/style.css
@@ -1,0 +1,37 @@
+/* 기본 스타일 */
+body {
+    font-family: 'Arial', sans-serif;
+    background-color: #f7f7f7;
+    padding: 20px;
+}
+
+/* 사용자 메시지 스타일 (우측 말풍선) */
+.user-message {
+    background-color: #d1e7ff;
+    padding: 10px 15px;
+    border-radius: 15px;
+    max-width: 70%;
+    margin-bottom: 10px;
+    align-self: flex-end;
+    position: relative;
+    word-wrap: break-word;
+}
+
+/* AI 메시지 스타일 (좌측 말풍선) */
+.ai-message {
+    background-color: #f0f0f0;
+    padding: 10px 15px;
+    border-radius: 15px;
+    max-width: 100%;
+    margin-bottom: 10px;
+    align-self: flex-start;
+    position: relative;
+    word-wrap: break-word;
+}
+
+/* 메시지 컨테이너 스타일 */
+.chat-container {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+}


### PR DESCRIPTION
## 개요
- 기본적인 사용자 ui 화면 제작
- 기본적인 틀만 구현해 놓은 상태로 추후 유사도 비교와 rag 연결과 그에 따른 ui 개선 필요

## 작업 내용
- 사용자 질의와 그에 따른 답변 ui 구현 ( 현재는 사용자 입력 그대로 출력 )
- 사용자 질의 창을 통한 문서 업로드
- 유사도 비교 정보를 보여줄 dialog 창
- 답변 재생성 버튼
- 새 대화 시작
- 이전 대화 내역

## 테스트 방법
- pip install streamlit
- 작업 폴더로 이동 후, streamlit run app.py

## 리뷰 요청 사항
- 사이드바 디자인에 대한 의견
- 추가 구현이 필요한 내용