### PR TITLE
[feat] vector db 테스트 코드 생성

### DIFF
--- a/research/sentence-bert/main.ipynb
+++ b/research/sentence-bert/main.ipynb
@@ -153,7 +153,7 @@
     "        pkl_list = [f for f in os.listdir(f\"{result_path}/preprocess/{path}\") if f.endswith(\".pkl\")]\n",
     "        for pkl_file in pkl_list:\n",
     "            with open(f\"{result_path}/preprocess/{path}/{pkl_file}\", \"rb\") as f2:\n",
-    "                encode_list = model.encode(pickle.load(f2))\n",
+    "                encode_list = model.encode(pickle.load(f2), normalize_embeddings=True)\n",
     "            with open(f\"{result_path}/encode/{path}/{pkl_file}\", \"wb\") as f2:\n",
     "                pickle.dump(encode_list, f2)\n",
     "\n",

--- a/research/vector-db/Annoy/annoy.ipynb
+++ b/research/vector-db/Annoy/annoy.ipynb
@@ -1,0 +1,113 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 필요한 모듈 설치\n",
+    "!pip3 install -r ./requirement.txt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 모듈 로드\n",
+    "from sentence_transformers import SentenceTransformer, util\n",
+    "from annoy import AnnoyIndex\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Annoy Class 구현\n",
+    "class AnnoyNearestNeighbor:\n",
+    "    def __init__(self, vectors, texts, metric='angular', n_trees=10): # angular = 코사인 유사도, euclidean : L2 거리\n",
+    "        self.texts = texts\n",
+    "        self.d = vectors.shape[1]\n",
+    "        self.index = AnnoyIndex(self.d, metric) # Annoy Index 생성\n",
+    "\n",
+    "        for i, vector in enumerate(vectors):\n",
+    "            self.index.add_item(i, vector)\n",
+    "        self.index.build(n_trees)\n",
+    "    \n",
+    "    def search(self, query_vector, top_k=1):\n",
+    "        indices, distances = self.index.get_nns_by_vector(query_vector, top_k, include_distances=True)\n",
+    "        # anglular의 거리는 1-코사인 유사도이므로 코사인 유사도를 구하기 위해 1을 제거\n",
+    "        similarities = [1 - (d/2) for d in distances]\n",
+    "        similar_texts = [self.texts[i] for i in indices]\n",
+    "        return similar_texts, similarities"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 테스트 코드 - Vector DB 구축\n",
+    "model = SentenceTransformer(\"jhgan/ko-sbert-sts\")\n",
+    "\n",
+    "text_list = [\n",
+    "    \"원숭이가 노래를 한다.\",\n",
+    "    \"배가 바다를 떠나 원대한 여정을 시작했다.\",\n",
+    "    \"그는 자신이 벌레만도 못한 취급을 받을 것이라곤 생각할 수 없었다.\"\n",
+    "]\n",
+    "text_vectors = model.encode(text_list, normalize_embeddings=True)\n",
+    "vector_db = AnnoyNearestNeighbor(text_vectors, text_list, metric='angular', n_trees=100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "유사 문장 : 배가 바다를 떠나 원대한 여정을 시작했다.\t유사도 :  0.9154\n",
+      "SBERT 유사도 :  0.9857\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 테스트 코드 - VectorDB 테스트\n",
+    "query_text = \"배가 바다를 떠나 원대한 여정을 시작함.\"\n",
+    "query_vector = model.encode(query_text, normalize_embeddings=True)\n",
+    "text, sim = vector_db.search(query_vector, 1)\n",
+    "print(f\"유사 문장 : {text[0]}\\t유사도 : {sim[0] : .4f}\")\n",
+    "print(f\"SBERT 유사도 : {float(util.cos_sim(model.encode(text), model.encode(query_text))) : .4f}\") # Annoy 유사도와 동일해야함!"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Capstone",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/research/vector-db/Annoy/requirement.txt
+++ b/research/vector-db/Annoy/requirement.txt
@@ -1,0 +1,3 @@
+annoy
+numpy
+sentence_transformers

--- a/research/vector-db/FAISS/faiss.ipynb
+++ b/research/vector-db/FAISS/faiss.ipynb
@@ -80,7 +80,7 @@
    ],
    "source": [
     "# 테스트 코드 - VectorDB 테스트\n",
-    "query_text = \"그배가 바다를 떠나 원대한 여정을 시작함.\"\n",
+    "query_text = \"배가 바다를 떠나 원대한 여정을 시작함.\"\n",
     "\n",
     "text, sim = vector_db.search(model.encode(query_text, normalize_embeddings=True))\n",
     "print(f\"유사 문장 : {text[0]}\\t유사도 : {sim[0] : .4f}\")\n",

--- a/research/vector-db/FAISS/faiss.ipynb
+++ b/research/vector-db/FAISS/faiss.ipynb
@@ -1,0 +1,112 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 필요한 모듈 설치\n",
+    "!pip3 install -r ./requirement.txt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 모듈 로드\n",
+    "from sentence_transformers import SentenceTransformer, util\n",
+    "import faiss\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# FAISS Class 구현\n",
+    "class FAISSNearestNeighbor:\n",
+    "    def __init__(self, vectors, texts):\n",
+    "        self.vectors = np.array(vectors).astype('float32')\n",
+    "        self.texts = texts\n",
+    "        self.d = self.vectors.shape[1] # 벡터 차원\n",
+    "        # faiss.normalize_L2(self.vectors) # 정규화는 SBERT에서 이미 하였으므로 생략\n",
+    "        self.index = faiss.IndexFlatIP(self.d)\n",
+    "        self.index.add(self.vectors)\n",
+    "    \n",
+    "    def search(self, query_vector, top_k=1):\n",
+    "        query_vector = np.array(query_vector).astype('float32').reshape(1, -1) # 입력 벡터는 1개이므로 reshape 필요\n",
+    "        # faiss.normalize_L2(self.vectors) # 정규화는 SBERT에서 이미 하였으므로 생략\n",
+    "        similarities, indices = self.index.search(query_vector, top_k)\n",
+    "        similar_texts = [self.texts[idx] for idx in indices[0]]\n",
+    "        return similar_texts, similarities[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 테스트 코드 - VectorDB 구축\n",
+    "model = SentenceTransformer(\"jhgan/ko-sbert-sts\")\n",
+    "\n",
+    "text_list = [\n",
+    "    \"원숭이가 노래를 한다.\",\n",
+    "    \"배가 바다를 떠나 원대한 여정을 시작했다.\",\n",
+    "    \"그는 자신이 벌레만도 못한 취급을 받을 것이라곤 생각할 수 없었다.\"\n",
+    "]\n",
+    "text_vectors = model.encode(text_list, normalize_embeddings=True)\n",
+    "vector_db = FAISSNearestNeighbor(text_vectors, text_list)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "유사 문장 : 배가 바다를 떠나 원대한 여정을 시작했다.\t유사도 :  0.9299\n",
+      "SBERT 유사도 :  0.9299\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 테스트 코드 - VectorDB 테스트\n",
+    "query_text = \"그배가 바다를 떠나 원대한 여정을 시작함.\"\n",
+    "\n",
+    "text, sim = vector_db.search(model.encode(query_text, normalize_embeddings=True))\n",
+    "print(f\"유사 문장 : {text[0]}\\t유사도 : {sim[0] : .4f}\")\n",
+    "print(f\"SBERT 유사도 : {float(util.cos_sim(model.encode(text), model.encode(query_text))) : .4f}\") # FAISS 유사도와 동일해야함!"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Capstone",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/research/vector-db/FAISS/requirement.txt
+++ b/research/vector-db/FAISS/requirement.txt
@@ -1,0 +1,3 @@
+faiss-cpu
+numpy
+sentence_transformers

--- a/research/vector-db/HNSWlib/hnswlib.ipynb
+++ b/research/vector-db/HNSWlib/hnswlib.ipynb
@@ -1,0 +1,113 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 필요한 모듈 설치\n",
+    "!pip3 install -r ./requirement.txt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 모듈 로드\n",
+    "import hnswlib\n",
+    "import numpy as np\n",
+    "from sentence_transformers import SentenceTransformer, util\n",
+    "from sklearn.metrics.pairwise import cosine_similarity"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# HNSW Class 구현\n",
+    "class HNDSWNearestNeighbor:\n",
+    "    def __init__(self, vectors, texts, space=\"cosine\", ef_construction=200, M=16):\n",
+    "        self.texts = texts\n",
+    "        self.d = vectors.shape[1]\n",
+    "        self.index = hnswlib.Index(space=space, dim=self.d)\n",
+    "        num_elements = len(vectors)\n",
+    "        self.index.init_index(max_elements=num_elements, ef_construction=ef_construction, M=M)\n",
+    "        for i, vector in enumerate(vectors):\n",
+    "            self.index.add_items(vector, i)\n",
+    "    \n",
+    "    def search(self, query_vector, top_k=1):\n",
+    "        labels, distances = self.index.knn_query(query_vector, k=top_k)\n",
+    "        similarities = [1- d for d in distances[0]]\n",
+    "        similar_texts = [self.texts[i] for i in labels[0]]\n",
+    "        return similar_texts, similarities"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 테스트 코드 - Vector DB 구축\n",
+    "model = SentenceTransformer(\"jhgan/ko-sbert-sts\")\n",
+    "\n",
+    "text_list = [\n",
+    "    \"원숭이가 노래를 한다.\",\n",
+    "    \"배가 바다를 떠나 원대한 여정을 시작했다.\",\n",
+    "    \"그는 자신이 벌레만도 못한 취급을 받을 것이라곤 생각할 수 없었다.\"\n",
+    "]\n",
+    "text_vectors = model.encode(text_list, normalize_embeddings=True)\n",
+    "vector_db = HNDSWNearestNeighbor(text_vectors, text_list, space=\"cosine\", ef_construction=200, M=16)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "유사 문장 : 배가 바다를 떠나 원대한 여정을 시작했다.\t유사도 :  0.9857\n",
+      "SBERT 유사도 :  0.9857\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 테스트 코드 - VectorDB 테스트\n",
+    "query_text = \"배가 바다를 떠나 원대한 여정을 시작함.\"\n",
+    "query_vector = model.encode(query_text, normalize_embeddings=True)\n",
+    "text, sim = vector_db.search(query_vector, 1)\n",
+    "print(f\"유사 문장 : {text[0]}\\t유사도 : {sim[0] : .4f}\")\n",
+    "print(f\"SBERT 유사도 : {float(util.cos_sim(model.encode(text), model.encode(query_text))) : .4f}\") # Annoy 유사도와 동일해야함!"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Capstone",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/research/vector-db/HNSWlib/requirement.txt
+++ b/research/vector-db/HNSWlib/requirement.txt
@@ -1,0 +1,4 @@
+hnswlib
+numpy
+sentence_transformers
+scikit-learn


### PR DESCRIPTION
## 개요
- FAISS, Annoy, HNSWlib 총 3가지 Vector DB 기술을 적용한 테스트 코드를 업로드 하여 추후 코드에 즉각적으로 적용할 수 있도록 설정

## 작업 내용
- ./research/vector-db/Annoy 하위에 Annoy DB 테스트 코드 업로드
- ./research/vector-db/FAISS 하위에 FAISS DB 테스트 코드 업로드
- ./research/vector-db/HNSWlib 하위에 HNSWlib DB 테스트 코드 업로드

## 테스트 방법
- 각 폴더의 `.ipynb` 파일을 모두 실행하면 결과가 나옵니다.

## 리뷰 요청 사항
- Annoy 방식을 제외한 2개 방식은 SBERT 유사도 검사와 결과가 동일한지 확인 부탁드립니다. Annoy 또한 오차는 있지만 근접한 값이 나오는 것이 좋습니다.