### PR TITLE
[refactor] RAG 코드 기능 업데이트 + 주석 추가

### DIFF
--- a/backend/rag/chat.py
+++ b/backend/rag/chat.py
@@ -3,7 +3,7 @@ from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 
 # LLM 모델 설정
-llm = ChatOllama(model="EEVE-Korean-10.8B:latest")
+llm = ChatOllama(model="EXAONE-3.5-7.8B-Instruct-Q8_0:latest")
 
 # Chatbot의 시스템 메시지 설정
 prompt = ChatPromptTemplate.from_messages(
@@ -17,16 +17,6 @@ prompt = ChatPromptTemplate.from_messages(
         MessagesPlaceholder(variable_name="messages")
     ]
 )
-
-rag_prompt = ChatPromptTemplate.from_template("""
-    다음 문맥을 기반으로 질문에 답변하세요.
-
-    문맥: {context}
-
-    질문: {question}
-
-    질문과 관련된 내용만 간략히 제공하세요. 민감하거나 무관한 정보는 제외하세요.
-""")
 
 # Chain : 여러 처리 단계를 연결하여 하나의 흐름으로 만드는 구조.
 # 프롬프트 -> LLM -> 출력

--- a/backend/rag/main.py
+++ b/backend/rag/main.py
@@ -2,53 +2,63 @@ import os
 import streamlit as st
 from langchain.prompts import ChatPromptTemplate
 from langchain_unstructured import UnstructuredLoader
+from langchain.embeddings import CacheBackedEmbeddings
 from langchain_huggingface import HuggingFaceEmbeddings
 from langchain.schema.runnable import RunnablePassthrough
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_community.vectorstores import FAISS
 from langchain_core.output_parsers import StrOutputParser
-from langchain_core.messages import HumanMessage
+from langchain.storage import LocalFileStore
 from langchain.schema import ChatMessage
 from langserve import RemoteRunnable
-from chat import chain as chat_chain, rag_prompt
+from langchain import hub
 
+# 실행하면 처음 뜨는 페이지 타이틀
 st.set_page_config(page_title="Ollama Local 모델 테스트", page_icon="💬")
 st.title("Ollama local 모델")
 
+# 시작하면서 chatbot이 "무엇을 도와드릴까요?"라며 채팅을 띄웁니다
 if "messages" not in st.session_state:
     st.session_state["messages"] = [
         ChatMessage(role="assistant", content="무엇을 도와드릴까요?")
     ]
 
+
+# 지금까지 주고받은 모든 메시지를 Streamlit 채팅 UI에 출력하는 코드
 def print_history():
     for msg in st.session_state.messages:
         st.chat_message(msg.role).write(msg.content)
 
+
+# 새로운 메시지를 채팅 기록(session_state)에 추가하는 함수
 def add_history(role, content):
     st.session_state.messages.append(ChatMessage(role=role, content=content))
 
+ 
+# 검색한 문서 결과를 하나의 문단으로 합쳐줍니다
 def format_docs(docs):
     return "\n\n".join(doc.page_content for doc in docs)
 
+
+# 파일을 올리면 Embedding file...이라 뜹니다
 @st.cache_resource(show_spinner="Embedding file...")
+
 
 # 올린 파일을 임베딩하는 코드
 def embed_file(file):
     file_content = file.read()
+
+    # 파일 저장 경로 설정
+    file_path = f"./.cache/files/{file.name}"
     
-    # 올린 파일을 저장할 공간(해당 파일에 자동 생성)
-    file_dir = "./.cache/files/"
-    file_path = os.path.join(file_dir, file.name)
-
-    embedding_dir = "./.cache/embeddings/"
-
-    os.makedirs(file_dir, exist_ok=True)
-    os.makedirs(embedding_dir, exist_ok=True)
-
+    # 읽은 파일을 임시 캐시에 저장
     with open(file_path, "wb") as f:
         f.write(file_content)
 
-    # 임의로 설정한 split size입니다. 
+    # 임배딩 캐시를 저장할 디렉토리 설정
+    cache_dir = LocalFileStore(f"./.cache/embeddings/{file.name}")
+
+    # 텍스트 분할기 설정 : 문서를 작은 청크로 나눕니다
     text_splitter = RecursiveCharacterTextSplitter(
         chunk_size=500,
         chunk_overlap=50,
@@ -56,58 +66,87 @@ def embed_file(file):
         length_function=len,
     )
 
-    # pdf 파일 로더
+    # pdf, docx, txt 파일 로더
     loader = UnstructuredLoader(file_path)
+
+    # 문서를 분할하여 docs 리스트로 만듭니다
     docs = loader.load_and_split(text_splitter=text_splitter)
 
-
-    model_path = "C:/Users/seclab/Dev/Langchain-ollama/model/ko-sbert-sts"
-    embeddings = HuggingFaceEmbeddings(model_name=model_path)
-
-    # 다른 분들은 이 코드로 편안히 임베딩 하시면 됩니다
-    # model_path = "jhgan/ko-sbert-sts"
-    # embeddings = HuggingFaceEmbeddings(model_name=model_path)
+    # Sbert 임베딩 모델 지정
+    model_name = "jhgan/ko-sbert-sts"
+    embeddings = HuggingFaceEmbeddings(model_name=model_name)
     
-    vectorstore = FAISS.from_documents(docs, embeddings)
+    # 임베딩 객체 생성 (속도를 향상시키기 위함입니다)
+    cached_embeddings = CacheBackedEmbeddings.from_bytes_store(embeddings, cache_dir)
+
+    # 문서 리스트를 벡터화 한 후에 FAISS 벡터 DB에 저장합니다
+    vectorstore = FAISS.from_documents(docs, cached_embeddings)
+    
+    # 검색기 형태로 반환하여 RAG 기능을 수행합니다
     retriever = vectorstore.as_retriever()
     return retriever
 
 with st.sidebar:
-    file = st.file_uploader("파일 업로드", type=["pdf", "txt", "docx"])
+    file = st.file_uploader(
+        "파일 업로드", 
+        type=["pdf", "txt", "docx"],
+        )
 
+# 파일을 올렸을 경우 retriever를 만들어 RAG 기능을 구현합니다
 if file:
     retriever = embed_file(file)
 
 print_history()
 
+# 사용자가 채팅을 입력했다면
 if user_input := st.chat_input():
+
+    # 1. 입력한 내용을 세션에 저장합니다
     add_history("user", user_input)
+
+    # 2. 화면에 사용자 메세지를 출력합니다
     st.chat_message("user").write(user_input)
 
+    # 3. chatbot의 응답 시작
     with st.chat_message("assistant"):
-        ollama = RemoteRunnable("http://localhost:8000/chat/")
 
+        # 로컬에서 돌리는 Ollama Langserver에 연결
+        ollama = RemoteRunnable("http://localhost:8000/chat")
 
         with st.spinner("답변을 생각하는 중입니다..."):
-            try:
-                if file is not None and any(keyword in user_input for keyword in ["파일", "문서", "내용", "설명", "정보"]):
-                    rag_chain = (
-                        {
-                            "context": retriever | (lambda docs: "\n\n".join(doc.page_content for doc in docs)),
-                            "question": RunnablePassthrough(),
-                        }
-                        # chat.py에서 가져온 rag의 prompt
-                        | rag_prompt
-                        | ollama
-                        | StrOutputParser()
-                    )
-                    answer = rag_chain.invoke(user_input)
-                else:
-                    # rag기능이 필요 없는 경우엔 chat.py의 기존 프롬프트를 그대로 이용
-                    answer = chat_chain.invoke({"messages": [HumanMessage(content=user_input)]})
+            if file is not None:
+                # Langchain이 제공하는 rag용 prompt -> 이건 chat.py에 rag용 prompt를 직접 만들까 고민중...
+                prompt = hub.pull("rlm/rag-prompt")
+
+                # Rag 체인 정의
+                rag_chain = (
+                    {
+                        "context": retriever | format_docs,  # 문석 검색 + 텍스트 포맷
+                        "question": RunnablePassthrough()    # 질문 원본 전달
+                    }
+                    | prompt    # Rag prompt를
+                    | ollama    # ollama 모델에 전달
+                    | StrOutputParser() # 모델 응답을 문자열로 parsing
+                )
+
+                # 문서에 대한 질의를 입력하고, 답변을 출력하빈다.
+                answer = rag_chain.invoke(
+                    user_input
+                )
 
                 add_history("ai", answer)
-                st.write(answer)
+            else:
+                # rag 안 썼을 경우(문서 없을 경우)
+                
+                prompt = ChatPromptTemplate.from_template(
+                    "다음의 질문에 간결하게 답변해주세요:\n{input}"
+                )
 
-            except Exception as e:
-                st.error(f"응답 생성 중 오류 발생: {str(e)}")
+                # 체인 생성
+                chain = prompt | ollama | StrOutputParser()
+
+                answer = chain.invoke(user_input)
+                add_history("ai", answer)
+        
+        # 답변 출력
+        st.write(answer)


### PR DESCRIPTION
[refactor] RAG 코드 기능 추가 + 주석 추가

## 개요
- 기존에는 인증서 문제 때문에 huggingface에서 embedding model을 불러오는 것이 불가능 했지만, 왜 인지는 모르겠지만 인증서 문제가 해결됬습니다. 따라서 코드를 그에 맞게 수정하였습니다.

## 작업 내용
- chat.py 에서 rag_prompt가 삭제되었습니다. 기존에는 직접 지정한 rag_prompt를 사용했었지만 인증서 문제가 해결되어서 main.py에서 langchain이 제공하는 rag용 prompt를 사용할 수 있게 되었습니다. 이에 따라 rag_prompt를 삭제했습니다.

- chat.py에서 기존의 LLM 모델을 수정했습니다(EEVE -> EXAONE). 상황에 맞지 않는 소리는 종종 하지만 그래도 성능을 올라간 것이 체감됩니다.

- main.py에선 embedding 방법이 바뀌였습니다. 기존 방법은 로컬은 되지만 ngrok으로 배포했을 땐 적용이 안되여서 배포했을 경우에도 RAG 기능이 정상적으로 기능하도록 바꿨습니다.

- main.py에 많은 주석을 달아놨습니다. 핵심 기능을 설명하는 주석을 중점으로 많이 추가했으니 코드 보기에 불편함이 없길 바랍니다. 

## 테스트 방법
- 제가 드린 주소(https://fancy-ghastly-hound.ngrok-free.app)로 들어가서 성능을 테스트하실 수 있습니다. 물론 제가 서버를 켰을 때만 되므로 테스트하기 전에 저한테 말해주세요.

## 리뷰 요청 사항
- 코드를 보고 궁금한 점이 있으면 질문해주시거나 테스트 결과에 문제가 있으면 말해주세요!